### PR TITLE
feat: add basic unit tests for ParseDependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/spf13/afero v1.6.0
+	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
@@ -9,10 +10,12 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -28,4 +31,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/fetch/dependencies.go
+++ b/pkg/fetch/dependencies.go
@@ -85,7 +85,7 @@ func (f *HelmDependencyFetch) fetchIndex(repo string) (*helm.Index, error) {
 }
 
 func (f *HelmDependencyFetch) fetchChart() (*helm.Chart, error) {
-	data, err := ioutil.ReadFile("Chart.yaml")
+	data, err := afero.ReadFile(f.Fs, "Chart.yaml")
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (f *HelmDependencyFetch) fetchChart() (*helm.Chart, error) {
 
 func (f *HelmDependencyFetch) fetchRequirements() (*[]helm.Dependency, error) {
 	requirements := helm.Requirements{}
-	data, err := ioutil.ReadFile("requirements.yaml")
+	data, err := afero.ReadFile(f.Fs, "requirements.yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fetch/dependencies_test.go
+++ b/pkg/fetch/dependencies_test.go
@@ -1,0 +1,46 @@
+package fetch
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDependenciesV2(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	chartBytes, err := ioutil.ReadFile("test_data/v2chart/Chart.yaml")
+	assert.Nil(t, err, "Unable to read Chart.yaml")
+
+	err = afero.WriteFile(fs, "Chart.yaml", chartBytes, 0644)
+	assert.Nil(t, err, "Unable to write Chart.yaml")
+
+	hdf := HelmDependencyFetch{Fs: fs}
+	deps, err := hdf.ParseDependencies()
+
+	assert.Nil(t, err, "Failed to parse ependencies from v2 Chart.yaml")
+	assert.Equal(t, 1, len(*deps), "Expected a single dependency to be parsed")
+}
+
+func TestParseDependenciesV1(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	chartBytes, err := ioutil.ReadFile("test_data/v1chart/Chart.yaml")
+	assert.Nil(t, err, "Unable to read Chart.yaml")
+
+	err = afero.WriteFile(fs, "Chart.yaml", chartBytes, 0644)
+	assert.Nil(t, err, "Unable to write Chart.yaml")
+
+	requirementsBytes, err := ioutil.ReadFile("test_data/v1chart/requirements.yaml")
+	assert.Nil(t, err, "Unable to read requirements.yaml")
+
+	err = afero.WriteFile(fs, "requirements.yaml", requirementsBytes, 0644)
+	assert.Nil(t, err, "Unable to write requirements.yaml")
+
+	hdf := HelmDependencyFetch{Fs: fs}
+	deps, err := hdf.ParseDependencies()
+
+	assert.Nil(t, err, "Failed to parse ependencies from v1 Chart.yaml")
+	assert.Equal(t, 1, len(*deps), "Expected a single dependency to be parsed")
+}

--- a/pkg/fetch/test_data/v1chart/Chart.yaml
+++ b/pkg/fetch/test_data/v1chart/Chart.yaml
@@ -1,0 +1,1 @@
+apiVersion: v1

--- a/pkg/fetch/test_data/v1chart/requirements.yaml
+++ b/pkg/fetch/test_data/v1chart/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: example
+  repository: http://localhost:8080/
+  version: ">= 1.0.0"

--- a/pkg/fetch/test_data/v2chart/Chart.yaml
+++ b/pkg/fetch/test_data/v2chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+dependencies:
+- name: example
+  repository: http://localhost:8080/
+  version: ">= 1.0.0"


### PR DESCRIPTION
- refactored the affected methods to start using afero, enabling
  these unit tests to be written
- added basic unit tests for parsing all-remote v1 and v2 charts