### PR TITLE
feat: avoid global for index cache

### DIFF
--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	f := fetch.HelmDependencyFetch{Fs: afero.NewOsFs()}
+	f := fetch.NewHelmDependencyFetch(afero.NewOsFs())
 
 	dependencies, err := f.ParseDependencies()
 	if err != nil {

--- a/pkg/fetch/dependencies.go
+++ b/pkg/fetch/dependencies.go
@@ -17,7 +17,16 @@ import (
 )
 
 type HelmDependencyFetch struct {
-	Fs afero.Fs
+	Fs      afero.Fs
+	Indexes map[string]helm.Index
+}
+
+func NewHelmDependencyFetch(fs afero.Fs) *HelmDependencyFetch {
+	hdf := HelmDependencyFetch{
+		Fs:      fs,
+		Indexes: map[string]helm.Index{},
+	}
+	return &hdf
 }
 
 func (f *HelmDependencyFetch) CreateChartsDirectory() error {
@@ -168,19 +177,17 @@ func (f *HelmDependencyFetch) fetchFileChart(path string) error {
 	return err
 }
 
-var indexes map[string]helm.Index = map[string]helm.Index{}
-
 func (f *HelmDependencyFetch) getIndex(repo string) (*helm.Index, error) {
 	var index helm.Index
 
-	if _, ok := indexes[repo]; !ok {
+	if _, ok := f.Indexes[repo]; !ok {
 		retrievedIndex, err := f.fetchIndex(repo)
 		if err != nil {
 			return nil, err
 		}
-		indexes[repo] = *retrievedIndex
+		f.Indexes[repo] = *retrievedIndex
 	}
 
-	index = indexes[repo]
+	index = f.Indexes[repo]
 	return &index, nil
 }

--- a/pkg/fetch/dependencies_test.go
+++ b/pkg/fetch/dependencies_test.go
@@ -22,7 +22,7 @@ func TestParseDependenciesV2(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	copyTestData(t, fs, "test_data/v2chart/Chart.yaml", "Chart.yaml")
 
-	hdf := HelmDependencyFetch{Fs: fs}
+	hdf := NewHelmDependencyFetch(fs)
 	deps, err := hdf.ParseDependencies()
 
 	assert.Nil(t, err, "Failed to parse ependencies from v2 Chart.yaml")
@@ -34,7 +34,7 @@ func TestParseDependenciesV1(t *testing.T) {
 	copyTestData(t, fs, "test_data/v1chart/Chart.yaml", "Chart.yaml")
 	copyTestData(t, fs, "test_data/v1chart/requirements.yaml", "requirements.yaml")
 
-	hdf := HelmDependencyFetch{Fs: fs}
+	hdf := NewHelmDependencyFetch(fs)
 	deps, err := hdf.ParseDependencies()
 
 	assert.Nil(t, err, "Failed to parse ependencies from v1 Chart.yaml")


### PR DESCRIPTION
Removed the global index cache and pushed into the
HelmDependencyFetch objects. Introduced a New func to initialise
these objects