### PR TITLE
breaking: provide a simpler testable API

### DIFF
--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -5,11 +5,10 @@ import (
 	"log"
 
 	"github.com/shteou/helm-dependency-fetch/pkg/fetch"
-	"github.com/spf13/afero"
 )
 
 func main() {
-	f := fetch.NewHelmDependencyFetch(afero.NewOsFs())
+	f := fetch.NewHelmDependencyFetch()
 
 	dependencies, err := f.ParseDependencies()
 	if err != nil {


### PR DESCRIPTION
- Callers should now use the empty New* func when instantiating
  HelmDependencyFetch which populates the struct with sensible
  defaults for production
- Added support for mocking http.Get
- Added a test for FetchVersion using the new mock support