### PR TITLE
fix: resolution of chart URLs

### DIFF
--- a/pkg/fetch/dependencies_test.go
+++ b/pkg/fetch/dependencies_test.go
@@ -107,6 +107,32 @@ func TestFetchVersion(t *testing.T) {
 			"foo": {{
 				Name:    "foo",
 				Version: "0.1.0",
+				Urls:    []string{"charts/foo-0.1.0-tgz"},
+			}},
+		},
+	}
+
+	// When
+	err := hdf.FetchVersion(helm.Dependency{Name: "foo", Repository: "http://localhost:8080", Version: ">= 0.1.0"})
+
+	// Then
+	assert.NoError(t, err, "Failed to fetch chart version")
+	stat, err := fs.Stat("charts/foo-0.1.0.tgz")
+	assert.NoError(t, err, "Failed to check existence of downloaded chart")
+	assert.Greater(t, stat.Size(), int64(10), "Resulting chart package should be more than a few bytes in size")
+}
+
+func TestFetchVersionAbsoluteUrl(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	fs.Mkdir("charts", 0777)
+	mockResponse := MockGetter{Response: &http.Response{Body: ioutil.NopCloser(bytes.NewReader([]byte("hello world")))}}
+	hdf := newHelmDependencyFetchTest(fs, mockResponse)
+	hdf.Indexes["http://localhost:8080"] = helm.Index{
+		Entries: map[string][]helm.Entry{
+			"foo": {{
+				Name:    "foo",
+				Version: "0.1.0",
+				Urls:    []string{"https://chart-repo.com/charts/foo-0.1.0-tgz"},
 			}},
 		},
 	}


### PR DESCRIPTION
Previously we used a hacky method to generate the chart package URL
from the repository URL, chart name, and chart version

Switched to a sightly more robust method which fetches the dependency
entry's Urls parameter (picking the first entry in the list) and
fetching that. If the URL is relative, it is appended to the repo
URL