### PR TITLE
refactor: split fetch package into multiple files

### DIFF
--- a/pkg/fetch/charts.go
+++ b/pkg/fetch/charts.go
@@ -1,0 +1,68 @@
+package fetch
+
+import (
+	"os"
+
+	"github.com/shteou/helm-dependency-fetch/pkg/helm"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v1"
+)
+
+func (f *HelmDependencyFetch) ParseDependencies() (*[]helm.Dependency, error) {
+	chart, err := f.fetchChart()
+	if err != nil {
+		return nil, err
+	}
+
+	if chart.APIVersion == "v1" {
+		return f.fetchRequirements()
+	}
+	return &chart.Dependencies, nil
+}
+
+func (f *HelmDependencyFetch) CreateChartsDirectory() error {
+	_, err := f.Fs.Stat("charts")
+	if os.IsNotExist(err) {
+		err = f.Fs.Mkdir("charts", 0755)
+		return err
+	}
+	return err
+}
+
+func (f *HelmDependencyFetch) fetchChart() (*helm.Chart, error) {
+	data, err := afero.ReadFile(f.Fs, "Chart.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	chart := helm.Chart{}
+	err = yaml.Unmarshal([]byte(data), &chart)
+
+	return &chart, err
+}
+
+func (f *HelmDependencyFetch) fetchRequirements() (*[]helm.Dependency, error) {
+	requirements := helm.Requirements{}
+	data, err := afero.ReadFile(f.Fs, "requirements.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal([]byte(data), &requirements)
+	return &requirements.Dependencies, err
+}
+
+func (f *HelmDependencyFetch) getIndex(repo string, username string, password string) (*helm.Index, error) {
+	var index helm.Index
+
+	if _, ok := f.Indexes[repo]; !ok {
+		retrievedIndex, err := f.fetchIndex(repo, username, password)
+		if err != nil {
+			return nil, err
+		}
+		f.Indexes[repo] = *retrievedIndex
+	}
+
+	index = f.Indexes[repo]
+	return &index, nil
+}

--- a/pkg/fetch/charts_test.go
+++ b/pkg/fetch/charts_test.go
@@ -1,0 +1,66 @@
+package fetch
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDependenciesV2(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	copyTestData(t, fs, "test_data/v2chart/Chart.yaml", "Chart.yaml")
+	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
+
+	// When
+	deps, err := hdf.ParseDependencies()
+
+	// Then
+	assert.NoError(t, err, "Failed to parse dependencies from v2 Chart.yaml")
+	assert.Equal(t, 1, len(*deps), "Expected a single dependency to be parsed")
+}
+
+func TestParseDependenciesV1(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	copyTestData(t, fs, "test_data/v1chart/Chart.yaml", "Chart.yaml")
+	copyTestData(t, fs, "test_data/v1chart/requirements.yaml", "requirements.yaml")
+	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
+
+	// When
+	deps, err := hdf.ParseDependencies()
+
+	// Then
+	assert.NoError(t, err, "Failed to parse dependencies from v1 Chart.yaml")
+	assert.Equal(t, 1, len(*deps), "Expected a single dependency to be parsed")
+}
+
+func TestCreateChartsDirectory(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
+
+	// When
+	err := hdf.CreateChartsDirectory()
+
+	// Then
+	assert.NoError(t, err, "Failed to call CreateChartsDirectory")
+
+	stat, err := fs.Stat("charts")
+	assert.NoError(t, err, "Failed to check existence of charts directory")
+	assert.True(t, stat.IsDir(), "charts should be a directory")
+}
+
+func TestCreateChartsDirectory_AlreadyExists(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	fs.Mkdir("charts", 0777)
+	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
+
+	// When
+	err := hdf.CreateChartsDirectory()
+
+	// Then
+	assert.NoError(t, err, "Failed to call CreateChartsDirectory")
+
+	stat, err := fs.Stat("charts")
+	assert.NoError(t, err, "Failed to check existence of charts directory")
+	assert.True(t, stat.IsDir(), "charts should be a directory")
+}

--- a/pkg/fetch/config.go
+++ b/pkg/fetch/config.go
@@ -1,0 +1,44 @@
+package fetch
+
+import (
+	"errors"
+	"path"
+
+	"github.com/shteou/helm-dependency-fetch/pkg/helm"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v1"
+	"helm.sh/helm/v3/pkg/helmpath"
+)
+
+// ParseRepositories loads the helm repositories config file,
+// if it exists.
+func (f *HelmDependencyFetch) parseRepositories() (*helm.Repositories, error) {
+	base := helmpath.ConfigPath()
+
+	data, err := afero.ReadFile(f.Fs, path.Join(base, "repositories.yaml"))
+
+	if errors.Is(err, afero.ErrFileNotFound) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	repositories := helm.Repositories{}
+	err = yaml.Unmarshal([]byte(data), &repositories)
+
+	return &repositories, err
+}
+
+func getCredsForRepository(repos *helm.Repositories, targetRepository string) (string, string) {
+	if repos == nil {
+		return "", ""
+	}
+
+	for _, repo := range repos.Repositories {
+		if repo.Url == targetRepository {
+			return repo.Username, repo.Password
+		}
+	}
+
+	return "", ""
+}

--- a/pkg/fetch/config_test.go
+++ b/pkg/fetch/config_test.go
@@ -1,0 +1,15 @@
+package fetch
+
+import (
+	"testing"
+
+	"github.com/shteou/helm-dependency-fetch/pkg/helm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCredsForRepository(t *testing.T) {
+	repos := helm.Repositories{Repositories: []helm.Repository{{Password: "foo", Username: "bar", Url: "http://localhost:8080"}}}
+	user, pass := getCredsForRepository(&repos, "http://localhost:8080")
+	assert.Equal(t, "foo", pass)
+	assert.Equal(t, "bar", user)
+}

--- a/pkg/fetch/dependencies.go
+++ b/pkg/fetch/dependencies.go
@@ -4,118 +4,20 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
-	"path"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/shteou/helm-dependency-fetch/pkg/helm"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v1"
-	"helm.sh/helm/v3/pkg/helmpath"
 )
-
-type HelmDependencyFetch struct {
-	Fs      afero.Fs
-	Get     Getter
-	Indexes map[string]helm.Index
-}
-
-type Getter interface {
-	Get(string, string, string) (*http.Response, error)
-}
-
-type NetworkGetter struct {
-}
-
-func (NetworkGetter) Get(url string, username string, password string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if username != "" {
-		req.SetBasicAuth(username, password)
-	}
-
-	client := &http.Client{
-		Timeout: time.Second * 60,
-	}
-
-	return client.Do(req)
-}
-
-func NewHelmDependencyFetch() *HelmDependencyFetch {
-	hdf := HelmDependencyFetch{
-		Fs:      afero.NewOsFs(),
-		Get:     NetworkGetter{},
-		Indexes: map[string]helm.Index{},
-	}
-	return &hdf
-}
-
-func (f *HelmDependencyFetch) CreateChartsDirectory() error {
-	_, err := f.Fs.Stat("charts")
-	if os.IsNotExist(err) {
-		err = f.Fs.Mkdir("charts", 0755)
-		return err
-	}
-	return err
-}
-
-// ParseRepositories loads the helm repositories config file,
-// if it exists.
-func (f *HelmDependencyFetch) ParseRepositories() (*helm.Repositories, error) {
-	base := helmpath.ConfigPath()
-
-	data, err := afero.ReadFile(f.Fs, path.Join(base, "repositories.yaml"))
-
-	if errors.Is(err, afero.ErrFileNotFound) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	repositories := helm.Repositories{}
-	err = yaml.Unmarshal([]byte(data), &repositories)
-
-	return &repositories, err
-}
-
-func (f *HelmDependencyFetch) ParseDependencies() (*[]helm.Dependency, error) {
-	chart, err := f.fetchChart()
-	if err != nil {
-		return nil, err
-	}
-
-	if chart.APIVersion == "v1" {
-		return f.fetchRequirements()
-	}
-	return &chart.Dependencies, nil
-}
-
-func getCredsForRepository(repos *helm.Repositories, targetRepository string) (string, string) {
-	if repos == nil {
-		return "", ""
-	}
-
-	for _, repo := range repos.Repositories {
-		if repo.Url == targetRepository {
-			return repo.Username, repo.Password
-		}
-	}
-
-	return "", ""
-}
 
 func (f *HelmDependencyFetch) FetchVersion(dependency helm.Dependency) error {
 	if !strings.HasPrefix(dependency.Repository, "file://") {
-		repos, err := f.ParseRepositories()
+		repos, err := f.parseRepositories()
 		if err != nil {
 			return err
 		}
@@ -178,27 +80,29 @@ func (f *HelmDependencyFetch) fetchIndex(repo string, username string, password 
 	return &index, nil
 }
 
-func (f *HelmDependencyFetch) fetchChart() (*helm.Chart, error) {
-	data, err := afero.ReadFile(f.Fs, "Chart.yaml")
+func (f *HelmDependencyFetch) fetchURLChart(url string, name string, version string, username string, password string) error {
+	fmt.Printf("\tFetching chart: %s\n", url)
+	resp, err := f.Get.Get(url, username, password)
 	if err != nil {
-		return nil, err
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
 	}
 
-	chart := helm.Chart{}
-	err = yaml.Unmarshal([]byte(data), &chart)
-
-	return &chart, err
+	err = afero.WriteFile(f.Fs, fmt.Sprintf("charts/%s-%s.tgz", name, version), body, 0644)
+	return err
 }
 
-func (f *HelmDependencyFetch) fetchRequirements() (*[]helm.Dependency, error) {
-	requirements := helm.Requirements{}
-	data, err := afero.ReadFile(f.Fs, "requirements.yaml")
-	if err != nil {
-		return nil, err
-	}
+func (f *HelmDependencyFetch) fetchFileChart(path string) error {
+	repoPath := strings.TrimPrefix(path, "file://")
 
-	err = yaml.Unmarshal([]byte(data), &requirements)
-	return &requirements.Dependencies, err
+	err := exec.Command("helm", "package", repoPath, "-d", "charts/").Run()
+
+	return err
 }
 
 func largestSemver(versions []*semver.Version) *semver.Version {
@@ -245,44 +149,4 @@ func resolveSemver(version string, entries []helm.Entry) (*semver.Version, *helm
 	}
 
 	return largest, findEntryByVersion(largest.Original(), entries), nil
-}
-
-func (f *HelmDependencyFetch) fetchURLChart(url string, name string, version string, username string, password string) error {
-	fmt.Printf("\tFetching chart: %s\n", url)
-	resp, err := f.Get.Get(url, username, password)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	err = afero.WriteFile(f.Fs, fmt.Sprintf("charts/%s-%s.tgz", name, version), body, 0644)
-	return err
-}
-
-func (f *HelmDependencyFetch) fetchFileChart(path string) error {
-	repoPath := strings.TrimPrefix(path, "file://")
-
-	err := exec.Command("helm", "package", repoPath, "-d", "charts/").Run()
-
-	return err
-}
-
-func (f *HelmDependencyFetch) getIndex(repo string, username string, password string) (*helm.Index, error) {
-	var index helm.Index
-
-	if _, ok := f.Indexes[repo]; !ok {
-		retrievedIndex, err := f.fetchIndex(repo, username, password)
-		if err != nil {
-			return nil, err
-		}
-		f.Indexes[repo] = *retrievedIndex
-	}
-
-	index = f.Indexes[repo]
-	return &index, nil
 }

--- a/pkg/fetch/dependencies_test.go
+++ b/pkg/fetch/dependencies_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/shteou/helm-dependency-fetch/pkg/getters"
 	"github.com/shteou/helm-dependency-fetch/pkg/helm"
 	"github.com/spf13/afero"
 
@@ -22,7 +23,7 @@ func (m MockGetter) Get(url string, username string, password string) (*http.Res
 	return m.Response, m.Error
 }
 
-func newHelmDependencyFetchTest(fs afero.Fs, getter Getter) *HelmDependencyFetch {
+func newHelmDependencyFetchTest(fs afero.Fs, getter getters.Getter) *HelmDependencyFetch {
 	hdf := HelmDependencyFetch{
 		Fs:      fs,
 		Get:     getter,
@@ -37,64 +38,6 @@ func copyTestData(t *testing.T, fs afero.Fs, src string, target string) {
 
 	err = afero.WriteFile(fs, target, bytes, 0644)
 	assert.Nil(t, err, fmt.Sprintf("Unable to write %s", target))
-}
-
-func TestParseDependenciesV2(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	copyTestData(t, fs, "test_data/v2chart/Chart.yaml", "Chart.yaml")
-	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
-
-	// When
-	deps, err := hdf.ParseDependencies()
-
-	// Then
-	assert.NoError(t, err, "Failed to parse ependencies from v2 Chart.yaml")
-	assert.Equal(t, 1, len(*deps), "Expected a single dependency to be parsed")
-}
-
-func TestParseDependenciesV1(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	copyTestData(t, fs, "test_data/v1chart/Chart.yaml", "Chart.yaml")
-	copyTestData(t, fs, "test_data/v1chart/requirements.yaml", "requirements.yaml")
-	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
-
-	// When
-	deps, err := hdf.ParseDependencies()
-
-	// Then
-	assert.NoError(t, err, "Failed to parse ependencies from v1 Chart.yaml")
-	assert.Equal(t, 1, len(*deps), "Expected a single dependency to be parsed")
-}
-
-func TestCreateChartsDirectory(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
-
-	// When
-	err := hdf.CreateChartsDirectory()
-
-	// Then
-	assert.NoError(t, err, "Failed to call CreateChartsDirectory")
-
-	stat, err := fs.Stat("charts")
-	assert.NoError(t, err, "Failed to check existence of charts directory")
-	assert.True(t, stat.IsDir(), "charts should be a directory")
-}
-
-func TestCreateChartsDirectory_AlreadyExists(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	fs.Mkdir("charts", 0777)
-	hdf := newHelmDependencyFetchTest(fs, MockGetter{})
-
-	// When
-	err := hdf.CreateChartsDirectory()
-
-	// Then
-	assert.NoError(t, err, "Failed to call CreateChartsDirectory")
-
-	stat, err := fs.Stat("charts")
-	assert.NoError(t, err, "Failed to check existence of charts directory")
-	assert.True(t, stat.IsDir(), "charts should be a directory")
 }
 
 func TestFetchVersion(t *testing.T) {
@@ -145,11 +88,4 @@ func TestFetchVersionAbsoluteUrl(t *testing.T) {
 	stat, err := fs.Stat("charts/foo-0.1.0.tgz")
 	assert.NoError(t, err, "Failed to check existence of downloaded chart")
 	assert.Greater(t, stat.Size(), int64(10), "Resulting chart package should be more than a few bytes in size")
-}
-
-func TestCredsForRepository(t *testing.T) {
-	repos := helm.Repositories{Repositories: []helm.Repository{{Password: "foo", Username: "bar", Url: "http://localhost:8080"}}}
-	user, pass := getCredsForRepository(&repos, "http://localhost:8080")
-	assert.Equal(t, "foo", pass)
-	assert.Equal(t, "bar", user)
 }

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -1,0 +1,22 @@
+package fetch
+
+import (
+	"github.com/shteou/helm-dependency-fetch/pkg/getters"
+	"github.com/shteou/helm-dependency-fetch/pkg/helm"
+	"github.com/spf13/afero"
+)
+
+type HelmDependencyFetch struct {
+	Fs      afero.Fs
+	Get     getters.Getter
+	Indexes map[string]helm.Index
+}
+
+func NewHelmDependencyFetch() *HelmDependencyFetch {
+	hdf := HelmDependencyFetch{
+		Fs:      afero.NewOsFs(),
+		Get:     getters.NetworkGetter{},
+		Indexes: map[string]helm.Index{},
+	}
+	return &hdf
+}

--- a/pkg/getters/network.go
+++ b/pkg/getters/network.go
@@ -1,0 +1,30 @@
+package getters
+
+import (
+	"net/http"
+	"time"
+)
+
+type Getter interface {
+	Get(string, string, string) (*http.Response, error)
+}
+
+type NetworkGetter struct {
+}
+
+func (NetworkGetter) Get(url string, username string, password string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if username != "" {
+		req.SetBasicAuth(username, password)
+	}
+
+	client := &http.Client{
+		Timeout: time.Second * 60,
+	}
+
+	return client.Do(req)
+}


### PR DESCRIPTION
Split out the fetch package into multiple files,
and extracted Getter interface into its own package