### PR TITLE
chore: upgrade workflow go version to 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
     -
       name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
The go.mod has been on 1.16 for some time, but the workflow lagged
behind on 1.15. This workflow runs go-releaser on tags, and 1.16
introduced native M1 support meaning this release should now be
automatically built