### PR TITLE
fix: avoid error on failed index fetch

### DIFF
--- a/pkg/fetch/dependencies.go
+++ b/pkg/fetch/dependencies.go
@@ -57,11 +57,11 @@ func (f *HelmDependencyFetch) fetchIndex(repo string, username string, password 
 	fmt.Printf("Fetching index from %s\n", repo)
 
 	resp, err := f.Get.Get(fmt.Sprintf("%s/index.yaml", strings.TrimSuffix(repo, "/")), username, password)
-	defer resp.Body.Close()
 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return nil, errors.New(fmt.Sprintf("Failed to retrieve index (status: %s)", resp.Status))


### PR DESCRIPTION
defer call to Close on response body iff the Get call succeeds
This avoids a panic (nil pointer dereference) when the call to
fetch the index json fails